### PR TITLE
Modhub 2.1.0.0 update

### DIFF
--- a/CVT_Addon.lua
+++ b/CVT_Addon.lua
@@ -90,10 +90,10 @@ source(CVTaddon.modDirectory.."events/SyncClientServerEvent.lua")
 source(g_currentModDirectory.."gui/CVTaddonGui.lua")
 g_gui:loadGui(g_currentModDirectory.."gui/CVTaddonGui.xml", "CVTaddonGui", CVTaddonGui:new())
 
-local scrversion = "0.9.9.119";
-local lastupdate = "10.3.2026"
-local timestamp = "1773153139592";
-local savetime = "15:32:19";
+local scrversion = "1.0.0.18";
+local lastupdate = "27.3.2026"
+local timestamp = "1774614632847";
+local savetime = "13:30:32";
 local modversion = CVTaddon.modversion; -- moddesc
 CVTaddon.build = scrversion
 
@@ -230,7 +230,7 @@ function CVTaddon.initSpecialization()
     schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#HSTstate", "HST state", 2)
     schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#inchingState", "inchingState", 1)
     schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#reverseLightsState", "reverseLightsState", 1)
-    schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#reverseLightsDurationState", "reverseLightsDurationState", 1)
+    schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#reverseLightsDurationState", "reverseLightsDurationState", 5)
     schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#brakeForceCorrectionState", "brakeForceCorrectionState", 9)
     schemaSavegame:register(XMLValueType.FLOAT, "vehicles.vehicle(?)."..key.."#brakeForceCorrectionValue", "brakeForceCorrectionValue", 1)
     schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?)."..key.."#drivingLevelState", "drivingLevelState", 3)
@@ -324,6 +324,7 @@ function CVTaddon:onRegisterActionEvents()
 			CVTaddon.actionEventsV10 = {}
 			CVTaddon.actionEventsGUI = {}
 			CVTaddon.actionEventsARWL = {}
+			CVTaddon.actionEventsTTL = {}
 			CVTaddon.actionEventsVCA1 = {}
 			CVTaddon.actionEventsVCA2 = {}
 			CVTaddon.actionEventsVCA3 = {}
@@ -331,6 +332,7 @@ function CVTaddon:onRegisterActionEvents()
 			CVTaddon.actionEventsGL = {}
 			local actionEventIdGui
 			local actionEventIdARwL
+			local actionEventIdTTL
 			local actionEventIdGL
 			local eventIdVCA1
 			local eventIdVCA2
@@ -472,6 +474,11 @@ function CVTaddon:onRegisterActionEvents()
 				g_inputBinding:setActionEventTextPriority(actionEventIdARwL, GS_PRIO_NORMAL)
 				g_inputBinding:setActionEventTextVisibility(actionEventIdARwL, true)
 			end
+			
+			_, actionEventIdTTL = self:addActionEvent(CVTaddon.actionEventsTTL, 'SETTOGGLETOPLIGHT', self, CVTaddon.toggleTopLights, false, true, false, true)
+			g_inputBinding:setActionEventTextPriority(actionEventIdTTL, GS_PRIO_NORMAL)
+			g_inputBinding:setActionEventTextVisibility(actionEventIdTTL, true)
+			
 			if self.spec_vca ~= nil then
 				-- additional for vca
 				_, eventIdVCA1 = self:addActionEvent(CVTaddon.actionEventsVCA1, 'SETVCAAWD', self, CVTaddon.VCAawd, false, true, false, true)
@@ -1355,6 +1362,35 @@ function CVTaddon:AccRampsSet4() -- BESCHLEUNIGUNGSRAMPEN IV
 		end -- g_client
 	end
 end -- AccRamps set4
+function CVTaddon:AccRampsSet4() -- BESCHLEUNIGUNGSRAMPEN IV
+	local spec = self.spec_CVTaddon
+	if spec.cvtAR >= 4 then
+		if g_client ~= nil then
+			if self.CVTaddon == nil then
+				return
+			end
+			if not CVTaddon.eventActiveV3set4 then
+				return
+			end
+			spec.vTwo = 4
+			-- DBL convert
+			spec.forDBL_accramp = (4)
+
+			if cvtaDebugCVTon then
+				print("AccRamp4 Taste gedrückt vTwo: "..tostring(spec.vTwo))
+				print("AccRamp4 Taste gedrückt acc: "..self.spec_motorized.motor.accelerationLimit)
+			end
+			self:raiseDirtyFlags(spec.dirtyFlag)
+			if g_server ~= nil then
+				g_server:broadcastEvent(SyncClientServerEvent.new(self, spec.HSTshuttle, spec.vOne, spec.vTwo, spec.vThree, spec.CVTCanStart, spec.vFive, spec.autoDiffs, spec.isVarioTM, spec.isTMSpedal, spec.CVTconfig, spec.forDBL_warnheat, spec.forDBL_critheat, spec.forDBL_warndamage, spec.forDBL_critdamage, spec.CVTdamage, spec.HandgasPercent, spec.ClutchInputValue, spec.cvtDL, spec.cvtAR, spec.VCAantiSlip, spec.VCApullInTurn, spec.CVTcfgExists, spec.reverseLightsState, spec.reverseLightsDurationState, spec.brakeForceCorrectionState, spec.brakeForceCorrectionValue, spec.drivingLevelState, spec.drivingLevelValue, spec.HSTstate, spec.preGlow, spec.forDBL_pregluefinished, spec.forDBL_glowingstate, spec.forDBL_preglowing, spec.HUDpos, spec.needClutchToStart), nil, nil, self)
+			else
+				g_client:getServerConnection():sendEvent(SyncClientServerEvent.new(self, spec.HSTshuttle, spec.vOne, spec.vTwo, spec.vThree, spec.CVTCanStart, spec.vFive, spec.autoDiffs, spec.isVarioTM, spec.isTMSpedal, spec.CVTconfig, spec.forDBL_warnheat, spec.forDBL_critheat, spec.forDBL_warndamage, spec.forDBL_critdamage, spec.CVTdamage, spec.HandgasPercent, spec.ClutchInputValue, spec.cvtDL, spec.cvtAR, spec.VCAantiSlip, spec.VCApullInTurn, spec.CVTcfgExists, spec.reverseLightsState, spec.reverseLightsDurationState, spec.brakeForceCorrectionState, spec.brakeForceCorrectionValue, spec.drivingLevelState, spec.drivingLevelValue, spec.HSTstate, spec.preGlow, spec.forDBL_pregluefinished, spec.forDBL_glowingstate, spec.forDBL_preglowing, spec.HUDpos, spec.needClutchToStart))
+			end
+			spec.forDBL_vmaxforward = tostring(self.spec_motorized.motor.maxForwardSpeed * 3.6)
+			spec.forDBL_vmaxbackward = tostring(self.spec_motorized.motor.maxBackwardSpeed * 3.6)
+		end -- g_client
+	end
+end -- AccRamps set4
 
 function CVTaddon:AccRampsSet5() -- BESCHLEUNIGUNGSRAMPEN V
 	local spec = self.spec_CVTaddon
@@ -1385,6 +1421,15 @@ function CVTaddon:AccRampsSet5() -- BESCHLEUNIGUNGSRAMPEN V
 		end -- g_client
 	end
 end -- AccRamps set5
+
+function CVTaddon:toggleTopLights() -- Top or bottom lights
+	local spec = self.spec_CVTaddon
+	if self.spec_lights.topLightsVisibility then
+		self:setTopLightsVisibility(false)
+	else
+		self:setTopLightsVisibility(true)
+	end
+end -- toggle top lights
 
 function CVTaddon:AccRamps() -- BESCHLEUNIGUNGSRAMPEN - Motorbremswirkung wird kontinuirlich berechnet @update
 	local spec = self.spec_CVTaddon
@@ -2422,7 +2467,7 @@ end
 
 -- function CVTaddon:setWarningLightsActive(active)
 --     local specLights = self.spec_lights
---     local bitWarningLight = 2 ^ 1 -- Beispiel-Bit für Warnblinker
+--     local bitWarningLight = 2 ^ 1 -- Bit für Warnblinker
 
 --     if specLights == nil then
 --         print("WARNUNG: spec_lights ist nil!")
@@ -2580,6 +2625,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 										if spec.ClutchInputValue < 0.6 then
 											if spec.needClutchToStart == 1 then
 												spec.CVTCanStart = false
+												-- print("6")
 											elseif spec.needClutchToStart == 2 then
 												spec.CVTCanStart = true
 											end
@@ -2594,6 +2640,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 										
 										if spec.HandgasPercent > 0.05 then
 											spec.CVTCanStart = false
+											-- print("7")
 											-- if g_client ~= nil and isActiveForInputIgnoreSelection and self:getCanMotorRun() == false then
 											if g_client ~= nil and isActiveForInputIgnoreSelection == false then
 												if not self.spec_RealisticDamageSystemEngineDied.EngineDied then
@@ -2613,6 +2660,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 											if cvtaDebugCVTcanStartOn then print("CVTa Hgas [F]: " .. tostring(spec.HandgasPercent)) end
 										else
 											spec.CVTCanStart = false
+											-- print("8")
 											-- if spec.needClutchToStart == 1 then
 											-- 	spec.CVTCanStart = false
 											-- elseif spec.needClutchToStart == 2 then
@@ -2677,6 +2725,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 									end
 								end
 								spec.CVTCanStart = false
+								-- print("9")
 							elseif spec.CVTCanStart == true and airTemp <= 2 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 250 then
 								if spec.preGlow == 0 then 
 									if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -2684,6 +2733,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 									end
 								end
 								spec.CVTCanStart = false
+								-- print("10")
 							elseif spec.CVTCanStart == true and airTemp <= -1 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 350 then
 								if spec.preGlow == 0 then 
 									if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -2691,6 +2741,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 									end
 								end
 								spec.CVTCanStart = false
+								-- print("11")
 							elseif spec.CVTCanStart == true and airTemp <= -4 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 480 then
 								if spec.preGlow == 0 then 
 									if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -2698,13 +2749,14 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 									end
 								end
 								spec.CVTCanStart = false
+								-- print("12")
 							elseif spec.CVTCanStart == true and (airTemp > 6 or self.spec_motorized.motorTemperature.value >= 40 ) then
 								spec.CVTCanStart = true
 							end
 						end
 					end
 					if ((g_ignitionLockManager:getIsAvailable() and self:getMotorState() == 1) or (not g_ignitionLockManager:getIsAvailable() and self:getMotorState() == 4)) and spec.preGlow ~= 0 then
-						if self.spec_motorized.motor.lastMotorRpm >= ( self.spec_motorized.motor.minRpm - 1 ) then
+						if self.spec_motorized.motor.lastMotorRpm >= ( self.spec_motorized.motor.minRpm + 100 ) then
 							spec.preGlow = 0
 						end
 						spec.forDBL_glowingstate = 0
@@ -3080,6 +3132,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 								end
 							end
 							spec.CVTCanStart = false
+							-- print("1")
 						elseif spec.CVTCanStart == true and airTemp <= 2 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 250 then
 							if spec.preGlow == 0 then 
 								if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -3087,6 +3140,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 								end
 							end
 							spec.CVTCanStart = false
+							-- print("2")
 						elseif spec.CVTCanStart == true and airTemp <= -1 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 350 then
 							if spec.preGlow == 0 then 
 								if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -3094,6 +3148,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 								end
 							end
 							spec.CVTCanStart = false
+							-- print("3")
 						elseif spec.CVTCanStart == true and airTemp <= -4 and self.spec_motorized.motorTemperature.value < 40 and spec.preGlow < 480 then
 							if spec.preGlow == 0 then 
 								if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -3101,6 +3156,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 								end
 							end
 							spec.CVTCanStart = false
+							-- print("4")
 						elseif spec.CVTCanStart == true and (airTemp > 6 or self.spec_motorized.motorTemperature.value >= 40 ) then
 							spec.CVTCanStart = true
 							-- print("CHECKPOINT 3b ###############")
@@ -3144,17 +3200,20 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 		if spec.forDBL_pregluefinished and spec.preGlow > 99 and self:getMotorState() == 1 then -- motor off
 			spec.preGlow = 0
 			spec.forDBL_pregluefinished = false
-			print("preGlow = 0")
-			print("pregluefinished = false")
+			-- print("preGlow = 0")
+			-- print("pregluefinished = false")
 		end
 
 		if not spec.forDBL_pregluefinished and spec.preGlow > 99 and spec.forDBL_glowingstate == 1 and self:getMotorState() >= 3 then -- motor on
 			-- spec.preGlow = 0
 			spec.forDBL_pregluefinished = true
-			print("pregluefinished = true")
+			-- print("pregluefinished = true")
 		end
 
 		-- print("state: " .. tostring(self:getMotorState()))
+		-- print("preGlow: " .. tostring(spec.preGlow))
+		-- print("forDBL_pregluefinished: " .. tostring(spec.forDBL_pregluefinished))
+		-- print("CVTCanStart: " .. tostring(spec.CVTCanStart))
 		-- print("zs: " .. tostring(g_ignitionLockManager:getIsAvailable() )) 
 
 		-- rebuild hst, hvst can starting
@@ -3408,7 +3467,10 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 					spec.CVTCanStart = true
 				else
 					-- print("set false ###########")
-					spec.CVTCanStart = false
+					if spec.forDBL_glowingstate == 1 then
+						spec.CVTCanStart = false	
+					end
+					-- print("5")
 				end
 
 				if self:getMotorState() > 3 then
@@ -3420,7 +3482,9 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 					if spec.preGlow == 0 then 
 						if g_ignitionLockManager:getIsAvailable() then
 							if self:getMotorState() > 1 and spec.forDBL_glowingstate == 0 then
-								g_currentMission:showBlinkingWarning(g_i18n:getText("txt_needpreGlow"), 75)
+								if g_client ~= nil and isActiveForInputIgnoreSelection == false then
+									g_currentMission:showBlinkingWarning(g_i18n:getText("txt_needpreGlow"), 75)
+								end
 							end
 						elseif not g_ignitionLockManager:getIsAvailable() then
 							if g_client ~= nil and isActiveForInputIgnoreSelection == false then
@@ -3707,7 +3771,7 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 					-- print("getCanMotorRun(): " .. tostring(self:getCanMotorRun()))
 				end
 				
-				if self:getMotorState() > 2 and self.spec_motorized.motor.lastMotorRpm >= self.spec_motorized.motor.minRpm - 1 then
+				if self:getMotorState() > 2 and self.spec_motorized.motor.lastMotorRpm >= self.spec_motorized.motor.minRpm + 100 then
 					spec.forDBL_glowingstate = 0
 				end
 

--- a/CVT_Addon.lua
+++ b/CVT_Addon.lua
@@ -46,6 +46,9 @@
 	-- spec.forDBL_drivinglevelcount
 	-- spec.forDBL_drivinglevel
 	-- spec.forDBL_tmspedalforDBL_tmspedal
+	-- forDBL_motorcoldlamp
+	-- forDBL_isvariotm
+	-- forDBL_ismanualtm
 
 --ToDo's
 	-- last changes
@@ -87,10 +90,10 @@ source(CVTaddon.modDirectory.."events/SyncClientServerEvent.lua")
 source(g_currentModDirectory.."gui/CVTaddonGui.lua")
 g_gui:loadGui(g_currentModDirectory.."gui/CVTaddonGui.xml", "CVTaddonGui", CVTaddonGui:new())
 
-local scrversion = "0.9.9.109";
-local lastupdate = "4.2.2026"
-local timestamp = "1770209242126";
-local savetime = "13:47:22";
+local scrversion = "0.9.9.119";
+local lastupdate = "10.3.2026"
+local timestamp = "1773153139592";
+local savetime = "15:32:19";
 local modversion = CVTaddon.modversion; -- moddesc
 CVTaddon.build = scrversion
 
@@ -123,21 +126,26 @@ peakMotorTorqueOrigin = 0
 
 
 function addCVTconfig(self, superfunc, xmlFile, baseXMLName, baseDir, customEnvironment, isMod, storeItem)
+
+	if (g_vehicleConfigurationManager:getNumOfConfigurationTypes() + 1) >= 2 ^ ConfigurationUtil.SEND_NUM_BITS then -- extract config limit fixed by Bene, thx to him
+        ConfigurationUtil.SEND_NUM_BITS = ConfigurationUtil.SEND_NUM_BITS + 1
+    end
+
     local configurations, defaultConfigurationIds = superfunc(self, xmlFile, baseXMLName, baseDir, customEnvironment, isMod, storeItem)
 	local category = storeItem.categoryName -- Category types for add_shopConfig
 	if 
-		(	category == "TRACTORSS" 		 or	category == "TRACTORSM"			 or	category == "TRACTORSL"
-		or	category == "HARVESTERS" 		 or	category == "FORAGEHARVESTERS" 	 or	category == "BEETVEHICLES"		or	category == "POTATOVEHICLES"
-		or 	category == "VEGETABLEHARVESTERS" or category == "SPINACHHARVESTERS" or category == "OLIVEVEHICLES"
-		or	category == "COTTONVEHICLES" 	 or	category == "SPRAYERVEHICLES"	 or  category == "SLURRYVEHICLES"	or	category == "SUGARCANEVEHICLES"
-		or	category == "MOWERVEHICLES"		 or	category == "MISCVEHICLES"		 or	category == "GRAPEVEHICLES"		or	category == "MOWERS"
-		or 	category == "FRONTLOADERVEHICLES" or category == "TELELOADERVEHICLES" or category == "SKIDSTEERVEHICLES" or category == "WHEELLOADERVEHICLES"
-		or 	category == "CARS" 				 or category == "TRUCKS" 			 or category == "MISC"
-		or 	category == "FORKLIFTS" 		 or category == "BEETHARVESTERS" 	 or category == "MISCDRIVABLES" 	or 	category == "HANDTOOLSMISC"
-		or 	category == "FORESTRYMISC"		or 	category == "WOODCHIPPERS"		or 	category == "FORESTRYEXCAVATORS" 
-		or 	category == "FORESTRYFORWARDERS" or category == "FORESTRYHARVESTERS" or category == "FORAGEMIXERS"		or 	category == "GRAPEHARVESTERS"
-		or 	category == "COTTONHARVESTERS"	or 	category == "SUGARCANEHARVESTERS"	or 	category == "RICEHARVESTERS" or category == "RICEPLANTERS"
-		or 	category == "PEAHARVESTERS"		or 	category == "GREENBEANHARVESTERS"	or 	category == "POTATOHARVESTING"
+		(	category == "TRACTORSS" 		  or	category == "TRACTORSM"			  or	category == "TRACTORSL"
+		or	category == "HARVESTERS" 		  or	category == "FORAGEHARVESTERS" 	  or	category == "BEETVEHICLES"		or	category == "POTATOVEHICLES"
+		or 	category == "VEGETABLEHARVESTERS" or 	category == "SPINACHHARVESTERS"   or 	category == "OLIVEVEHICLES"
+		or	category == "COTTONVEHICLES" 	  or	category == "SPRAYERVEHICLES"	  or 	category == "SLURRYVEHICLES"	or	category == "SUGARCANEVEHICLES"
+		or	category == "MOWERVEHICLES"		  or	category == "MISCVEHICLES"		  or	category == "GRAPEVEHICLES"		or	category == "MOWERS"
+		or 	category == "FRONTLOADERVEHICLES" or 	category == "TELELOADERVEHICLES"  or 	category == "SKIDSTEERVEHICLES" or  category == "WHEELLOADERVEHICLES"
+		or 	category == "CARS" 				  or 	category == "TRUCKS" 			  or 	category == "MISC"
+		or 	category == "FORKLIFTS" 		  or 	category == "BEETHARVESTERS" 	  or 	category == "MISCDRIVABLES" 	or 	category == "HANDTOOLSMISC"
+		or 	category == "FORESTRYMISC"		  or 	category == "WOODCHIPPERS"		  or 	category == "FORESTRYEXCAVATORS" 
+		or 	category == "FORESTRYFORWARDERS"  or 	category == "FORESTRYHARVESTERS"  or 	category == "FORAGEMIXERS"		or 	category == "GRAPEHARVESTERS"
+		or 	category == "COTTONHARVESTERS"	  or 	category == "SUGARCANEHARVESTERS" or 	category == "RICEHARVESTERS" 	or  category == "RICEPLANTERS"
+		or 	category == "PEAHARVESTERS"		 or 	category == "GREENBEANHARVESTERS" or 	category == "POTATOHARVESTING"
 		or 	category == "BEETLOADING"
 
 		--DLCs
@@ -653,6 +661,8 @@ function CVTaddon:onLoad(savegame)
 	spec.forDBL_brakescale = 0.0
 	spec.forDBL_autoreverseworklight = 1
 	spec.forDBL_autoreverseworklightseconds = 3
+	spec.forDBL_ismanualtm = false
+	spec.forDBL_isvariotm = false
 	
 	-- #GLOWIN-TEMP-SYNC
 	-- spec.SyncMotorTemperature = 20 -- temp
@@ -671,7 +681,7 @@ function CVTaddon:onLoad(savegame)
 
 	if spec.vOne ~= nil then
 		if not spec.isVarioTM then
-			spec.forDBL_drivinglevel = (7)
+			spec.forDBL_drivinglevel = tostring("n")
 		else
 			spec.forDBL_drivinglevel = (spec.vOne)
 		end
@@ -885,6 +895,8 @@ function CVTaddon:onPostLoad(savegame)
 	spec.forDBL_highpressure = 0
 	spec.forDBL_autoreverseworklight = 1
 	spec.forDBL_autoreverseworklightseconds = 3
+	spec.forDBL_ismanualtm = false
+	spec.forDBL_isvariotm = false
 	if spec.CVTdamage ~= nil then
 		spec.forDBL_cvtwear = spec.CVTdamage
 	else
@@ -903,7 +915,7 @@ function CVTaddon:onPostLoad(savegame)
 
 	if spec.vOne ~= nil then
 		if not spec.isVarioTM then
-			spec.forDBL_drivinglevel = (7)
+			spec.forDBL_drivinglevel = tostring("n")
 			-- spec.forDBL_drivinglevel = tostring(" ")
 		else
 			spec.forDBL_drivinglevel = (spec.vOne)
@@ -919,7 +931,7 @@ function CVTaddon:onPostLoad(savegame)
 	spec.forDBL_digitalhandgasstep = (spec.vFive)
 	if spec.vTwo ~= nil then
 		if not spec.isVarioTM then
-			spec.forDBL_accramp = (7)
+			spec.forDBL_accramp = tostring("n")
 			-- spec.forDBL_accramp = tostring(" ")
 		else
 			spec.forDBL_accramp = (spec.vTwo)
@@ -2469,6 +2481,8 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 	local isFFF = storeItem.categoryName == "FORKLIFTS"
 	local samples = specMF.samples
 	spec.isVarioTM = self.spec_motorized.motor.lastManualShifterActive == false and self.spec_motorized.motor.groupType == 1 and self.spec_motorized.motor.gearType == 1 and self.spec_motorized.motor.forwardGears == nil
+	spec.forDBL_isvariotm = spec.isVarioTM
+	spec.forDBL_ismanualtm = not spec.isVarioTM
 	if self.spec_motorized.motorTemperature.valueMin == 20 then
 		self.spec_motorized.motorTemperature.valueMin = -10
 	end
@@ -3089,15 +3103,15 @@ function CVTaddon:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSelec
 							spec.CVTCanStart = false
 						elseif spec.CVTCanStart == true and (airTemp > 6 or self.spec_motorized.motorTemperature.value >= 40 ) then
 							spec.CVTCanStart = true
-							print("CHECKPOINT 3b ###############")
+							-- print("CHECKPOINT 3b ###############")
 						else
 							spec.CVTCanStart = true
-							print("CHECKPOINT 3a ###############")
+							-- print("CHECKPOINT 3a ###############")
 						end
 					end
 				end
 			else
-				print("CHECKPOINT else")
+				-- print("CHECKPOINT else")
 				if ((g_ignitionLockManager:getIsAvailable() and self:getMotorState() == 1) or (not g_ignitionLockManager:getIsAvailable() and self:getMotorState() == 4)) and spec.preGlow ~= 0 then
 					if self.spec_motorized.motor.lastMotorRpm >= ( self.spec_motorized.motor.minRpm - 10 ) and spec.CVTconfig ~= 9 then
 						-- if spec.forDBL_pregluefinished then -- new gluefinish fail!
@@ -7003,7 +7017,7 @@ function CVTaddon:onReadStream(streamId, connection)
 
 	if spec.vOne ~= nil then
 		if not spec.isVarioTM then
-			spec.forDBL_drivinglevel = (7)
+			spec.forDBL_drivinglevel = tostring("n")
 		else
 			spec.forDBL_drivinglevel = (spec.vOne)
 		end

--- a/l10n/modDesc_l10n_de.xml
+++ b/l10n/modDesc_l10n_de.xml
@@ -146,6 +146,7 @@ Stellt man diesen Wert nun auf geringe, wären es 22 km/h, sehr gering dann 15.5
 		<text name="input_SETVARIOADIFFS" text="CVTa: AWD und DIFF Automatik" />
 		<text name="input_CVT_SHOWGUI" text="CVTa: Einstellungen Menü öffnen" />
 		<text name="input_CVT_TOGGLEARWL" text="CVTa: Umschalten Auto-Arbeitslicht Rückwärts fahren" />
+		<text name="input_SETTOGGLETOPLIGHT" text="CVTa: Umschalten Toplichter oder Bottomlichter" />
 		<text name="input_SETVARIORPM_AXIS" text="CVTa: Handgas Achse" />
 		<text name="input_SETVARIORPMP" text="CVTa: Motordrehzahl erhöhen" />
 		<text name="input_SETVARIORPMM" text="CVTa: Motordrehzahl verringern" />

--- a/l10n/modDesc_l10n_en.xml
+++ b/l10n/modDesc_l10n_en.xml
@@ -84,7 +84,7 @@ Depending on the manufacturer, even retail hydromotors." />
 		<text name="selection_accRamp_10" text="10" />
 		<text name="selection_accRamp_01" text="1" />
 		<text name="selection_active" text="Activated" />
-		<text name="selection_deactive" text="Deaching" />
+		<text name="selection_deactive" text="Deactivated" />
 		<text name="selection_BF_20" text="20%" />
 		<text name="selection_BF_30" text="30%" />
 		<text name="selection_BF_40" text="40%" />
@@ -114,7 +114,7 @@ are hereby reduced or increased.For example, a stepless vehicle with 2 driving a
 If you place this value on low, it would be 22 kph, very little then 15.5 kph.The same applies.Higher, 28 kph and very high 31 kph." />
 		<text name="CVTAgui_drivingLevelStateTitle" text="Speed adaptation" />
 		<text name="CVTAgui_HSTshuttleT" text="How change Drivedirection" />
-		<text name="CVTAgui_startWithClutchSettingTitle" text="Kupplung zum starten" />
+		<text name="CVTAgui_startWithClutchSettingTitle" text="Clutch for enginestart" />
 		
 		<text name="selection_DLC_10000" text="very low" />
 		<text name="selection_DLC_01000" text="less" />

--- a/l10n/modDesc_l10n_en.xml
+++ b/l10n/modDesc_l10n_en.xml
@@ -148,6 +148,7 @@ If you place this value on low, it would be 22 kph, very little then 15.5 kph.Th
 		<text name="input_SETVARIOADIFFS" text="CVTa: AWD and DIFF Automatic" />
 		<text name="input_CVT_SHOWGUI" text="CVTa: Open settings menu" />
 		<text name="input_CVT_TOGGLEARWL" text="CVTa: Toggle Auto-Worklight reversedrive" />
+		<text name="input_SETTOGGLETOPLIGHT" text="CVTa: Toggle between toplights and bottomlights" />
 		<text name="input_SETVARIORPM_AXIS" text="CVTa: Handgas axis" />
 		<text name="input_SETVARIORPMP" text="CVTa: Increase the engine speed" />
 		<text name="input_SETVARIORPMM" text="CVTa: Reduce the engine speed" />

--- a/l10n/modDesc_l10n_es.xml
+++ b/l10n/modDesc_l10n_es.xml
@@ -19,9 +19,9 @@
 		<text name="cvtgui_Cvthud" text="visibilidad" />
 		<text name="CVTAgui_CvthudPos" text="posición" />
 		<text name="variantTT" text="Elija una variante de transmisión; hay muchas transmisiones continuamente variables (CVT) diferentes.." />
-		<text name="HSTshuttleStateSettingTT" text="Fahrzeuge mir Pedalwippe oder 2 Pedalsystem können alternativ mit der Kupplung den Richtungswechseln vornehmen.
-Modernere Maschinen z.B. Hoflader haben u.a. am Joystick einen Taster für diese Funktion." />
-		<text name="startWithClutchTT" text="Das treten des Kupplungspedales wird vorrausgesetzt, wie es bei einigen Fahrzeugen auch in RL ist - und bei anderen widerrum nicht." />
+		<text name="HSTshuttleStateSettingTT" text="Los vehículos con sistema de pedales basculantes o de dos pedales pueden usar el embrague para cambiar de dirección.
+Las máquinas más modernas, como las cargadoras de ruedas, cuentan con un botón para esta función en el joystick, entre otros elementos." />
+		<text name="startWithClutchTT" text="Es necesario pisar el pedal del embrague, como ocurre con algunos vehículos en la vida real, pero no con otros." />
 		<text name="CvthudTT" text="Mostrar o deshabilitar la visualización del HUD." />
 		<text name="CvthudPOSTT" text="Posicionamiento de la pantalla HUD." />
 		<text name="CVTAguiHUD_on" text="a" />

--- a/l10n/modDesc_l10n_es.xml
+++ b/l10n/modDesc_l10n_es.xml
@@ -19,6 +19,9 @@
 		<text name="cvtgui_Cvthud" text="visibilidad" />
 		<text name="CVTAgui_CvthudPos" text="posición" />
 		<text name="variantTT" text="Elija una variante de transmisión; hay muchas transmisiones continuamente variables (CVT) diferentes.." />
+		<text name="HSTshuttleStateSettingTT" text="Fahrzeuge mir Pedalwippe oder 2 Pedalsystem können alternativ mit der Kupplung den Richtungswechseln vornehmen.
+Modernere Maschinen z.B. Hoflader haben u.a. am Joystick einen Taster für diese Funktion." />
+		<text name="startWithClutchTT" text="Das treten des Kupplungspedales wird vorrausgesetzt, wie es bei einigen Fahrzeugen auch in RL ist - und bei anderen widerrum nicht." />
 		<text name="CvthudTT" text="Mostrar o deshabilitar la visualización del HUD." />
 		<text name="CvthudPOSTT" text="Posicionamiento de la pantalla HUD." />
 		<text name="CVTAguiHUD_on" text="a" />
@@ -109,6 +112,8 @@ Este ajuste permite influir en el cálculo resultante y ajustarlo para lograr un
 		<text name="drivingLevelStateTT" text="La velocidad máxima para rangos de conducción más bajos, o las rampas límite para HST y cosechadoras, se reduce o aumenta aquí. Por ejemplo, un vehículo de variación continua con dos rangos de conducción circula a máxima velocidad (50 km/h) en el rango 2 y a media velocidad (25 km/h) en el rango 1.
 Si este valor se establece ahora en bajo, sería de 22 km/h, y en muy bajo, de 15,5 km/h. Lo mismo ocurre con rangos más altos: alto, 28 km/h, y muy alto, 31 km/h." />
 		<text name="CVTAgui_drivingLevelStateTitle" text="Ajuste de velocidad" />
+		<text name="CVTAgui_HSTshuttleT" text="Richtungswechselart" />
+		<text name="CVTAgui_startWithClutchSettingTitle" text="Kupplung zum starten" />
 		<text name="selection_DLC_10000" text="muy bajo" />
 		<text name="selection_DLC_01000" text="más bajo" />
 		<text name="selection_DLC_00100" text="Normal" />
@@ -119,6 +124,10 @@ Si este valor se establece ahora en bajo, sería de 22 km/h, y en muy bajo, de 1
 		<text name="selection_hst_hst" text="HST" />
 		<text name="selection_hst_hydrostat" text="Hidrostato" />
 		<text name="selection_hst_brake" text="Pedal de acelerador único" />
+		<text name="selection_noClutch" text="Keine Kupplung" />
+		<text name="selection_withCluth" text="Mit Kupplung" />
+		<text name="selection_shuttle_shift" text="Wechseltaster" />
+		<text name="selection_shuttle_clutch" text="Kupplungspedal" />
 		<text name="text_HST_installed_short" text="hidrostato HST" />
 		<text name="text_CVT_Installed_short" text="Activo" />
 		<text name="text_CVT_Installed_desc" text="Complemento CVT activo y configurable en la GUI." />
@@ -129,6 +138,8 @@ Si este valor se establece ahora en bajo, sería de 22 km/h, y en muy bajo, de 1
 		<text name="input_SETVARIOTWO" text="CVTa: Zona de conducción 2" />
 		<text name="input_SETVARIO3" text="CVTa: Zona de conducción 3" />
 		<text name="input_SETVARIO4" text="CVTa: Zona de conducción 4" />
+		<text name="input_SETVARIOUP" text="CVTa: Fahrbereich erhöhen" />
+		<text name="input_SETVARIODN" text="CVTa: Fahrbereich verringern" />
 		<text name="input_SETVARIOTOGGLE" text="CVTa: Cambiar áreas de conducción" />
 		<text name="input_SETVARION" text="CVTa: Neutral" />
 		<text name="input_SETVARIOADIFFS" text="CVTa: AWD y DIFF automático" />
@@ -142,6 +153,10 @@ Si este valor se establece ahora en bajo, sería de 22 km/h, y en muy bajo, de 1
 		<text name="input_SETPREGLOW" text="CVTa: Velas pre-encendidas" />
 		<text name="input_SIGNAL_HIGH_BEAM" text="CVTa: Luces altas, luces de cruce para adelantar" />
 		<text name="input_SIGNAL_HOLD_BEAM" text="CVTa: Intermitente de luces altas" />
+		<text name="input_SETVCAAWD" text="VCA: Allrad umschalten" />
+		<text name="input_SETVCAFRONTDIFF" text="VCA: Differentialsperre Vorne" />
+		<text name="input_SETPIPELIGHT" text="CVT: Pipelicht umschalten" />
+		<text name="input_SETVCAREARDIFF" text="VCA: Differentialsperre Hinten" />
 		<text name="input_LMBF_TOGGLE_RAMP" text="CVTa: Aumentar la rampa de aceleración" />
 		<text name="input_LMBF_TOGGLE_RAMPT" text="CVTa: Cambiar rampa de aceleración" />
 		<text name="input_LMBF_TOGGLE_RAMPS1" text="CVTa: Cambiar a la rampa de aceleración 1" />

--- a/l10n/modDesc_l10n_pt.xml
+++ b/l10n/modDesc_l10n_pt.xml
@@ -18,9 +18,9 @@
 		<text name="cvtgui_Cvthud" text="Visibilidade" />
 		<text name="CVTAgui_CvthudPos" text="Posição" />
 		<text name="variantTT" text="Selecione a variante da transmissão, existe uma variedade de diferentes transmissões contínuas." />
-		<text name="HSTshuttleStateSettingTT" text="Fahrzeuge mir Pedalwippe oder 2 Pedalsystem können alternativ mit der Kupplung den Richtungswechseln vornehmen.
-Modernere Maschinen z.B. Hoflader haben u.a. am Joystick einen Taster für diese Funktion." />
-		<text name="startWithClutchTT" text="Das treten des Kupplungspedales wird vorrausgesetzt, wie es bei einigen Fahrzeugen auch in RL ist - und bei anderen widerrum nicht." />
+		<text name="HSTshuttleStateSettingTT" text="Veículos com sistema de pedal basculante ou de dois pedais podem, alternativamente, usar a embreagem para mudar de direção.
+Máquinas mais modernas, como pás carregadeiras, possuem um botão para essa função no joystick, entre outros recursos." />
+		<text name="startWithClutchTT" text="É necessário pressionar o pedal da embreagem, como acontece com alguns veículos na vida real, mas não com outros." />
 		<text name="CvthudTT" text="HUD Visível ou desativar o ecrã." />
 		<text name="CvthudPOSTT" text="Posição do HUD." />
 		<text name="CVTAguiHUD_on" text="ligado" />
@@ -110,10 +110,10 @@ Modernere Maschinen z.B. Hoflader haben u.a. am Joystick einen Taster für diese
 		<text name="selection_hst_hst" text="HST" />
 		<text name="selection_hst_hydrostat" text="Hidrostato" />
 		<text name="selection_hst_brake" text="Pedal de condução único" />
-		<text name="selection_noClutch" text="Keine Kupplung" />
-		<text name="selection_withCluth" text="Mit Kupplung" />
-		<text name="selection_shuttle_shift" text="Wechseltaster" />
-		<text name="selection_shuttle_clutch" text="Kupplungspedal" />
+		<text name="selection_noClutch" text="Sem embreagem" />
+		<text name="selection_withCluth" text="Com embreagem" />
+		<text name="selection_shuttle_shift" text="interruptor de alternância" />
+		<text name="selection_shuttle_clutch" text="pedal da embreagem" />
 		<text name="text_HST_installed_short" text="HST Hidrostato" />
 		<text name="text_CVT_Installed_short" text="Ativo" />
 		<text name="text_CVT_Installed_desc" text="CVT-Addon ativo e configurável na GUI." />

--- a/l10n/modDesc_l10n_pt.xml
+++ b/l10n/modDesc_l10n_pt.xml
@@ -18,6 +18,9 @@
 		<text name="cvtgui_Cvthud" text="Visibilidade" />
 		<text name="CVTAgui_CvthudPos" text="Posição" />
 		<text name="variantTT" text="Selecione a variante da transmissão, existe uma variedade de diferentes transmissões contínuas." />
+		<text name="HSTshuttleStateSettingTT" text="Fahrzeuge mir Pedalwippe oder 2 Pedalsystem können alternativ mit der Kupplung den Richtungswechseln vornehmen.
+Modernere Maschinen z.B. Hoflader haben u.a. am Joystick einen Taster für diese Funktion." />
+		<text name="startWithClutchTT" text="Das treten des Kupplungspedales wird vorrausgesetzt, wie es bei einigen Fahrzeugen auch in RL ist - und bei anderen widerrum nicht." />
 		<text name="CvthudTT" text="HUD Visível ou desativar o ecrã." />
 		<text name="CvthudPOSTT" text="Posição do HUD." />
 		<text name="CVTAguiHUD_on" text="ligado" />
@@ -107,6 +110,10 @@
 		<text name="selection_hst_hst" text="HST" />
 		<text name="selection_hst_hydrostat" text="Hidrostato" />
 		<text name="selection_hst_brake" text="Pedal de condução único" />
+		<text name="selection_noClutch" text="Keine Kupplung" />
+		<text name="selection_withCluth" text="Mit Kupplung" />
+		<text name="selection_shuttle_shift" text="Wechseltaster" />
+		<text name="selection_shuttle_clutch" text="Kupplungspedal" />
 		<text name="text_HST_installed_short" text="HST Hidrostato" />
 		<text name="text_CVT_Installed_short" text="Ativo" />
 		<text name="text_CVT_Installed_desc" text="CVT-Addon ativo e configurável na GUI." />
@@ -117,11 +124,14 @@
 		<text name="input_SETVARIOTWO" text="CVTa: Nível de Condução 2" />
 		<text name="input_SETVARIO3" text="CVTa: Nível de Condução 3" />
 		<text name="input_SETVARIO4" text="CVTa: Nível de Condução 4" />
+		<text name="input_SETVARIOUP" text="CVTa: Fahrbereich erhöhen" />
+		<text name="input_SETVARIODN" text="CVTa: Fahrbereich verringern" />
 		<text name="input_SETVARIOTOGGLE" text="CVTa: Alternar Nível de Condução" />
 		<text name="input_SETVARION" text="CVTa: Neutro" />
 		<text name="input_SETVARIOADIFFS" text="CVTa: AWD e Diferencial Automático" />
 		<text name="input_CVT_SHOWGUI" text="CVTa: Abrir menu de configurações" />
 		<text name="CVT_TOGGLEARWL" text="CVTa: Alternar Luz de Trabalho Automática ao inverter" />
+		<text name="input_SETTOGGLETOPLIGHT" text="CVTa: Umschalten Toplichter oder Bottomlichter" />
 		<text name="input_SETVARIORPM_AXIS" text="CVTa: Eixo do acelerador manual" />
 		<text name="input_SETVARIORPMP" text="CVTa: Aumentar a velocidade do motor" />
 		<text name="input_SETVARIORPMM" text="CVTa: Reduzir a velocidade do motor" />
@@ -130,6 +140,10 @@
 		<text name="input_SETPREGLOW" text="CVTa: Pré-aquecer velas de incandescência" />
 		<text name="input_SIGNAL_HIGH_BEAM" text="CVTa: Flash de máximos" />
 		<text name="input_SIGNAL_HOLD_BEAM" text="CVTa: Flash de máximos" />
+		<text name="input_SETVCAAWD" text="VCA: Allrad umschalten" />
+		<text name="input_SETVCAFRONTDIFF" text="VCA: Differentialsperre Vorne" />
+		<text name="input_SETPIPELIGHT" text="CVT: Pipelicht umschalten" />
+		<text name="input_SETVCAREARDIFF" text="VCA: Differentialsperre Hinten" />
 		<text name="input_LMBF_TOGGLE_RAMP" text="CVTa: Aumentar a rampa de aceleração" />
 		<text name="input_LMBF_TOGGLE_RAMPT" text="CVTa: Alternar rampa de aceleração" />
 		<text name="input_LMBF_TOGGLE_RAMPS1" text="CVTa: Mudar a rampa de aceleração 1" />

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="106">
+<modDesc descVersion="107">
     <author>SbSh</author>
 	<contributor>Glowin</contributor>
 	<version>2.1.0.0</version>
@@ -282,8 +282,7 @@ https://github.com/SbSh-DNA-ModDing/FS25_CVT_Addon_Dev
   dadurch können nun Missionsfahrzeug eingestellt werden.
  - Fahrbereiche Tasten für hoch- und runterschalten hinzugefügt.
  - Sprachen um PT und ES aus der Communitiy erwitert.
- - Vorglühen bei manuellen Fahrzeugen ging der Motor sofort wieder aus,
-   ist gefixt.
+ - Vorglühen bei manuellen Fahrzeugen ging der Motor sofort wieder aus, ist gefixt.
  - mit FS25_DashboardLive zusammen, der Motor wärmt auf oder kühlt ab außerhalb des Fahrzeugs.
  - DBL Telemetrieausgabe erweitert und optimiert.
 ]]></de>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="105">
+<modDesc descVersion="106">
     <author>SbSh</author>
 	<contributor>Glowin</contributor>
-	<version>2.c.1.4</version>
+	<version>2.c.1.5</version>
 	<title>
         <en>CVT Addon</en>
     </title>
@@ -387,6 +387,5 @@ https://github.com/s4t4n/FS25_CVT_Addon
 		<actionBinding action="SETPIPELIGHT">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
 		</actionBinding>
-		
 	</inputBinding>
 </modDesc>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2,7 +2,7 @@
 <modDesc descVersion="106">
     <author>SbSh</author>
 	<contributor>Glowin</contributor>
-	<version>2.c.1.5</version>
+	<version>2.1.0.0</version>
 	<title>
         <en>CVT Addon</en>
     </title>
@@ -125,7 +125,25 @@ Likewise, telemetry output for telemetry from Upsidedown.
 e.g., automatic work lights currently active.
 Further information in the Wiki.
 
-Feedback and bug reports (and Wiki) are welcome at: https://github.com/s4t4n/FS25_CVT_Addon please.
+Feedback and bug reports (and Wiki) are welcome at: https://github.com/SbSh-DNA-ModDing/FS25_CVT_Addon_Dev please.
+
+- Changelog: 2.1.0.0
+ - Glow plug notification was visible to all clients.
+ - Fixed HST sync error in multiplayer.
+ - HST/hydrostat can now change direction via keybind, which some real-life vehicles have.
+ - Requirement to press clutch for starting is now configurable.
+ - Removed EV support due to multiplayer incompatibilities.
+ - Added differential keybindings for VCA.
+ - Added DLC vehicles to the shop.
+ - Separate keybinding for pipe light.
+ - Keybinding to manually switch between top and bottom lights.
+ - Shop config is enabled by default but configuration remains inactive, allowing mission vehicles to be set.
+ - Added keybindings for shifting driving ranges up and down.
+ - Added PT and ES community translations.
+ - Fixed issue where manual vehicle engines stalled immediately after preheating.
+ - Engine heats up or cools down while outside the vehicle when used with FS25_DashboardLive.
+ - Expanded and optimized DBL telemetry output.
+
 ]]></en>
         <de>
 <![CDATA[
@@ -247,7 +265,7 @@ z.B. Automatische Arbeitsscheinwerfer gerade aktiv.
 Weitere Infos im Wiki.
 
 Feedback und Fehlerberichte (und Wiki) gerne unter:
-https://github.com/s4t4n/FS25_CVT_Addon
+https://github.com/SbSh-DNA-ModDing/FS25_CVT_Addon_Dev
 
 - Changelog: 2.1.0.0
  - Textmeldung daß man vorgrlühen muß war für alle clients sichtbar
@@ -259,12 +277,15 @@ https://github.com/s4t4n/FS25_CVT_Addon
  - Differential Tastenbelegung für VCA hinzugefügt.
  - DLC Fahrzeuge im Shop hinzugefügt.
  - Tastenbelegung für das Rohrlicht einzeln.
+ - Tastenbelegung um das Top- und Bottomlicht manuell zu wechseln.
  - Shopconfig ist standartmäßg aktiviert, Konfiguration bleibt aber auf inaktiv,
   dadurch können nun Missionsfahrzeug eingestellt werden.
  - Fahrbereiche Tasten für hoch- und runterschalten hinzugefügt.
  - Sprachen um PT und ES aus der Communitiy erwitert.
  - Vorglühen bei manuellen Fahrzeugen ging der Motor sofort wieder aus,
    ist gefixt.
+ - mit FS25_DashboardLive zusammen, der Motor wärmt auf oder kühlt ab außerhalb des Fahrzeugs.
+ - DBL Telemetrieausgabe erweitert und optimiert.
 ]]></de>
     </description> 
 
@@ -304,6 +325,7 @@ https://github.com/s4t4n/FS25_CVT_Addon
         <action name="SETVCAREARDIFF" />
         <action name="SETVCAFRONTDIFF" />
         <action name="SETPIPELIGHT" />
+        <action name="SETTOGGLETOPLIGHT" />
     </actions>
 	<inputBinding>
 		<actionBinding action="SETVARIOONE">
@@ -387,5 +409,9 @@ https://github.com/s4t4n/FS25_CVT_Addon
 		<actionBinding action="SETPIPELIGHT">
 			<binding device="KB_MOUSE_DEFAULT" input="" />
 		</actionBinding>
+		<actionBinding action="SETTOGGLETOPLIGHT">
+			<binding device="KB_MOUSE_DEFAULT" input="" />
+		</actionBinding>
+		
 	</inputBinding>
 </modDesc>


### PR DESCRIPTION
- Changelog: 2.1.0.0
  - Glow plug notification was visible to all clients.
  - Fixed HST sync error in multiplayer.
  - HST/hydrostat can now change direction via keybind, which some real-life vehicles have.
  - Requirement to press clutch for starting is now configurable.
  - Removed EV support due to multiplayer incompatibilities.
  - Added differential keybindings for VCA.
  - Added DLC vehicles to the shop.
  - Separate keybinding for pipe light.
  - Keybinding to manually switch between top and bottom lights.
  - Shop config is enabled by default but configuration remains inactive, allowing mission vehicles to be set.
  - Added keybindings for shifting driving ranges up and down.
  - Added PT and ES community translations.
  - Fixed issue where manual vehicle engines stalled immediately after preheating.
  - Engine heats up or cools down while outside the vehicle when used with FS25_DashboardLive.
  - Expanded and optimized DBL telemetry output.